### PR TITLE
Fix Signing Keys

### DIFF
--- a/bin/deploy-uaa
+++ b/bin/deploy-uaa
@@ -13,4 +13,4 @@ docker run -d --name uaa --net rabbitmq_net \
     ./gradlew run
 
 echo "Monitor the logs (docker logs uaa -f). UAA will be ready when you see 'Task :cargoRunLocal' "
-echo "Once UAA is ready; run 'make setup-users-and-tokens' before starting any application and/or rabbitmq"
+echo "Once UAA is ready; run 'make setup-users-and-clients' before starting any application and/or rabbitmq"

--- a/bin/rabbitmq.config
+++ b/bin/rabbitmq.config
@@ -1,31 +1,23 @@
 [
-    % Enable auth backend
-    {rabbit, [
-        {auth_backends, [rabbit_auth_backend_oauth2, rabbit_auth_backend_internal]}
-    ]},
-
-    {rabbitmq_management, [
+  % Enable auth backend
+  {rabbit, [
+     {auth_backends, [rabbit_auth_backend_oauth2, rabbit_auth_backend_internal]}
+  ]},
+  {rabbitmq_management, [
          {enable_uaa, true},
          {uaa_client_id, "rabbit_client"},
          {uaa_location, "http://localhost:8080/uaa"}
-    ]},
-
-    {rabbitmq_auth_backend_oauth2, [
+  ]},
+  {rabbitmq_auth_backend_oauth2, [
     {resource_server_id, <<"rabbitmq">>},
     {key_config, [
       {default_key, <<"legacy-token-key">>},
-      {signing_keys,
-        #{<<"legacy-token-key">> => {pem, <<"-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
-6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
-IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
-B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
-2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
-QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
-VwIDAQAB
------END PUBLIC KEY-----">>}
-         }
-      }]
-    }
+      {signing_keys, #{
+        <<"legacy-token-key">> => {map, #{<<"kty">> => <<"MAC">>,
+                                  <<"alg">> => <<"HS256">>,
+                                  <<"use">> => <<"sig">>,
+                                  <<"value">> => <<"tokenKey">>}}
+      }}
+    ]}
   ]}
 ].


### PR DESCRIPTION
**Description**
This PR replaces the hardcoded key in `bin/rabbitmq.config` with a map.

**The Issue This PR Fixes**
Having followed the steps 1 through 4 in the README file, and after logging in with Cloud Foundry with either user `rabbit_admin` or `rabbit_monitor`, we are redirected to the Management Portal for Rabbitmq but it refuses to display the web portal and by looking into the logs we get this error message:
`[warning] <0.882.0> HTTP access denied: user 'rabbit_client' - invalid credentials`

**Minor Fixes**
After running `make setup-uaa` we get `run 'make setup-users-and-tokens` but this make target doesn't exist but is called `make setup-users-and-clients`.